### PR TITLE
error para el primer dia de los meses con 31 dias

### DIFF
--- a/ej6.c
+++ b/ej6.c
@@ -81,6 +81,7 @@ int ej6(){
                 montha=1;
             }
         } else if (day==1){
+          monthb=month-1;
             if (month==8||month==1){
                 dayb=31;
             } else if (month==3){


### PR DESCRIPTION
al mostrar el dia anterior seguia mostrando el mes actual y no el anterior, es el unico error que descubri de pedo por que puse mi cumpleaños y lo puse mal jajajaja habria que revisar el resto del [codigo](https://pbs.twimg.com/media/CXWIWorWwAAez2R.png) .